### PR TITLE
Replace "http" with "httpclient" 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     groupme-api (0.4.0)
       http (~> 3.0)
+      httpclient (~> 2.8)
 
 GEM
   remote: https://rubygems.org/
@@ -55,6 +56,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
+    httpclient (2.8.3)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     groupme-api (0.4.0)
-      http (~> 3.0)
       httpclient (~> 2.8)
 
 GEM
@@ -28,8 +27,6 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.25)
     formatador (0.2.5)
     guard (2.14.2)
@@ -47,15 +44,6 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.7)
-    http (3.3.0)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.0)
-      http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    http-form_data (2.1.1)
-    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
@@ -126,9 +114,6 @@ GEM
     tins (1.16.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)

--- a/groupme-api.gemspec
+++ b/groupme-api.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.files        = `git ls-files`.split("\n")
   spec.require_path = 'lib'
 
-  spec.add_dependency 'http', '~> 3.0'
   spec.add_dependency 'httpclient', '~> 2.8'
 
   spec.add_development_dependency 'bundler',          '~> 1.16'

--- a/groupme-api.gemspec
+++ b/groupme-api.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_path = 'lib'
 
   spec.add_dependency 'http', '~> 3.0'
+  spec.add_dependency 'httpclient', '~> 2.8'
 
   spec.add_development_dependency 'bundler',          '~> 1.16'
   spec.add_development_dependency 'coveralls',        '~> 0.8'

--- a/lib/groupme.rb
+++ b/lib/groupme.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'http'
 require 'httpclient'
 require 'json'
 

--- a/lib/groupme.rb
+++ b/lib/groupme.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'http'
+require 'httpclient'
 require 'json'
 
 require 'groupme/configuration'

--- a/lib/groupme/request.rb
+++ b/lib/groupme/request.rb
@@ -13,10 +13,11 @@ module GroupMe
       @method = method
       @path   = path
       @opts   = opts
+      @client = HTTPClient.new(base_url: API_BASE_URI, default_header: { 'Content-Type': 'application/json' })
     end
 
     def send
-      response = HTTP.request(@method, full_uri, params: full_opts)
+      response = @client.request(@method, full_uri, query: full_opts)
       Response.new(response)
     end
 

--- a/spec/groupme/response_spec.rb
+++ b/spec/groupme/response_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GroupMe::Response do
 
   describe '.raw' do
     it 'should return an HTTP::Response object' do
-      expect(response.raw).to be_an_instance_of(HTTP::Response)
+      expect(response.raw).to be_an_instance_of(HTTP::Message)
     end
   end
 


### PR DESCRIPTION
# Description

[vcr](https://github.com/vcr/vcr) does not support `http` when stubbing with WebMock. Replaced with `httpclient` because its API was straight-forward, intuitive, and much simpler when compared to `net/http` and `typhoeus`.

# Changes
- Replace `http` with `httpclient`